### PR TITLE
Ignore local client connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ exports.init = function (sbot, config) {
   )
 
   sbot.on('rpc:connect', function (rpc) {
+    if (rpc.id === sbot.id) return
     blobs._onConnect(rpc, rpc.id)
   })
   return blobs


### PR DESCRIPTION
Don't replicate blobs if the remote id is the same as a local id: assume that the RPC is a CLI or master client.

I found this while debugging why a RPC instance wasn't closing properly, and it turned out to be because ssb-blobs was calling an RPC method while the PacketStream instance was being destroyed, resulting in deadlock. This should probably be fixed in packet-stream or muxrpc somehow, but fixing it here makes the problem that I was seeing go away, for now.