### PR TITLE
Fix local calls to blobs.createWants

### DIFF
--- a/test/local.js
+++ b/test/local.js
@@ -1,0 +1,32 @@
+var tape = require('tape')
+var pull = require('pull-stream')
+var assert = require('assert')
+
+var u = require('./util')
+
+module.exports = function (createBlobs, createAsync) {
+
+  tape('createWants does not error after abort', function (t) {
+    createAsync(function (async) {
+      var blobs = createBlobs('simple', async)
+      var wants = blobs.createWants.call({id: 'test'})
+      // abort the want stream, and then make another one
+      wants(new Error('abort'), function (err) {
+        t.ok(err, 'wants aborted')
+        pull(
+          blobs.createWants.call({id: 'test'}),
+          async.through(),
+          pull.take(1),
+          pull.collect(function (err, res) {
+            t.error(err, 'wants')
+            t.deepEquals(res, [{}], 'empty wants')
+            t.end()
+          })
+        )
+      })
+    })
+  })
+
+}
+
+if(!module.parent) u.tests(module.exports)


### PR DESCRIPTION
When calling createWants locally, currently the initial object is not send on calls subsequent to the first call. This PR fixes this by cleaning up the createWants stream when it is aborted.