### PR TITLE
Use debug for quieter tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "cont": "^1.0.3",
+    "debug": "^4.1.1",
     "level": "^4.0.0",
     "multiblob": "^1.12.0",
     "pull-level": "^2.0.4",
@@ -17,7 +18,7 @@
     "ssb-ref": "^2.3.0"
   },
   "devDependencies": {
-    "interleavings": "^0.3.1",
+    "interleavings": "github:fraction/interleavings#debug-console-log",
     "mkdirp": "^0.5.1",
     "osenv": "^0.1.3",
     "pull-bitflipper": "^0.1.0",

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,3 +1,4 @@
+const debug = require('debug')('ssb-blobs')
 var tape = require('tape')
 var Blobs = require('../inject')
 var pull = require('pull-stream')
@@ -14,7 +15,7 @@ module.exports = function (createBlobs, createAsync) {
   function log (name) {
     if(LOGGING)
       return pull.through(function (e) {
-        console.log(name, e)
+        debug(name, e)
       })
     else
       return pull.through()
@@ -31,9 +32,9 @@ module.exports = function (createBlobs, createAsync) {
 
       alice.want(h, function (err, has) {
         if(err) throw err
-        console.log('ALICE has?', h, has)
+        debug('ALICE has?', h, has)
         alice.has(h, function (err, has) {
-          console.log('ALICE has!', h, has)
+          debug('ALICE has!', h, has)
           if(err) throw err
           assert.ok(has)
           async.done()
@@ -103,7 +104,7 @@ module.exports = function (createBlobs, createAsync) {
   tape('peers want what you have', function (t) {
     createAsync(function (async) {
       if(Array.isArray(process._events['exit']))
-        console.log(process._events['exit'].reverse())
+        debug(process._events['exit'].reverse())
       var alice = createBlobs('alice', async)
       var bob   = createBlobs('bob', async)
       var carol = createBlobs('carol', async)
@@ -184,7 +185,7 @@ module.exports = function (createBlobs, createAsync) {
       pull(
         bob.changes(),
         pull.drain(function (_h) {
-          console.log('HAS', _h)
+          debug('HAS', _h)
           assert.equal(_h, h)
           async.done()
         })

--- a/test/legacy.js
+++ b/test/legacy.js
@@ -1,3 +1,4 @@
+const debug = require('debug')('ssb-blobs')
 var tape = require('tape')
 var Blobs = require('../inject')
 var pull = require('pull-stream')
@@ -72,9 +73,9 @@ module.exports = function (createBlobs, createAsync) {
 
       var size = legacy.size
       legacy.size = function (hashes, cb) {
-        console.log("CALLED_SIZE", hashes)
+        debug("CALLED_SIZE", hashes)
         size.call(this, hashes, function (err, value) {
-          console.log('SIZES', err, value)
+          debug('SIZES', err, value)
           cb(err, value)
         })
       }
@@ -96,11 +97,11 @@ module.exports = function (createBlobs, createAsync) {
 
       pull(pull.once(blob), legacy.add(function (err, _h) {
         assert.equal(_h, h)
-        console.log('ADDED', _h)
+        debug('ADDED', _h)
       }))
 
     }, function (err) {
-      console.log(err)
+      debug(err)
       if(err) throw err
       t.end()
     })

--- a/test/mock/blobs.js
+++ b/test/mock/blobs.js
@@ -1,3 +1,4 @@
+const debug = require('debug')('ssb-blobs')
 var pull = require('pull-stream')
 var crypto = require('crypto')
 var cont = require('cont')
@@ -100,7 +101,7 @@ module.exports = function MockBlobStore (name, async) {
         if(err) return cb(err)
         data = Buffer.concat(data)
         var h = add(data, _hash)
-        console.log('..ADDED', name, h)
+        debug('..ADDED', name, h)
         if(!h) cb(new Error('wrong hash'))
         else {
           notify({id: h, size: data.length, ts: Date.now()})

--- a/test/mock/set.js
+++ b/test/mock/set.js
@@ -1,5 +1,6 @@
+const debug = require('debug')('ssb-blobs')
 module.exports = function (async) {
-  console.log(async)
+  debug(async)
   var set = {}
   return {
     set: set,

--- a/test/push.js
+++ b/test/push.js
@@ -1,3 +1,4 @@
+const debug = require('debug')('ssb-blobs')
 var tape = require('tape')
 var Blobs = require('../inject')
 var pull = require('pull-stream')
@@ -36,12 +37,12 @@ module.exports = function (createBlobs, createAsync) {
 
       pull(alice.pushed(), pull.drain(function (data) {
         assert.deepEqual(data, {key: h, peers: {bob: 64, carol: 64, dan: 64}})
-        console.log("PUSHED", data)
+        debug("PUSHED", data)
         cont.para([bob, carol, dan].map(function (p) {
           return cont(p.has)(h)
         }))
           (function (err, ary) {
-            console.log('HAS', err, ary)
+            debug('HAS', err, ary)
             if(err) throw err
             assert.deepEqual(ary, [true, true, true])
             async.done()

--- a/test/simple.js
+++ b/test/simple.js
@@ -1,3 +1,4 @@
+const debug = require('debug')('ssb-blobs')
 var tape = require('tape')
 var pull = require('pull-stream')
 var assert = require('assert')
@@ -13,11 +14,11 @@ module.exports = function (createBlobs, createAsync) {
   tape('simple', function (t) {
     createAsync(function (async) {
       var blobs = createBlobs('simple', async)
-      console.log(blobs)
+      debug(blobs)
       var b = Fake('hello', 256), h = hash(b)
       pull(pull.once(b), async.through(), blobs.add(h, function (err, _h) {
         if(err) throw err
-        console.log('added', _h)
+        debug('added', _h)
         t.equal(_h, h)
 
         var req = {}
@@ -37,7 +38,7 @@ module.exports = function (createBlobs, createAsync) {
           pull.take(2),
           pull.collect(function (err, _res) {
             if(err) throw err
-            console.log("_RES", _res)
+            debug("_RES", _res)
             assert.deepEqual(_res, [{}, res])
             async.done()
           })
@@ -77,7 +78,7 @@ module.exports = function (createBlobs, createAsync) {
         pull.take(2),
         pull.collect(function (err, _res) {
   //        c++
-          console.log('END', c, _res)
+          debug('END', c, _res)
           assert.deepEqual(_res, [{}, res])
           async.done()
 //          throw new Error('called thrice')
@@ -85,7 +86,7 @@ module.exports = function (createBlobs, createAsync) {
       )
 
     }, function (err, results) {
-      console.log(err)
+      debug(err)
       if(err) throw err
       t.end()
     })
@@ -161,7 +162,7 @@ module.exports = function (createBlobs, createAsync) {
 //        pull.find(null, function (err, _res) {
 //          if(err) throw err
 //          //requests 
-//          console.log(_res)
+//          debug(_res)
 //          t.fail('should not have sent any message')
 //          async.done()
 //        })

--- a/test/util.js
+++ b/test/util.js
@@ -1,10 +1,11 @@
+const debug = require('debug')('ssb-blobs')
 var pull = require('pull-stream')
 var crypto = require('crypto')
 
 var log = exports.log = function log (name) {
   if(process.env.DEBUG)
     return pull.through(function (e) {
-      console.log(name, e)
+      debug(name, e)
     })
   else
     return pull.through()


### PR DESCRIPTION
See https://github.com/ssbc/ssb-server/issues/624

## Before

`npm test` produces ~15k lines of output

## After

`npm test` produces ~400 lines of output