### PR TITLE
Update level and rimraf

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "cont": "^1.0.3",
     "debug": "^4.1.1",
-    "level": "^5.0.1",
+    "level": "^6.0.0",
     "multiblob": "^1.12.0",
     "pull-level": "^2.0.4",
     "pull-notify": "^0.1.0",
@@ -22,7 +22,7 @@
     "mkdirp": "^0.5.1",
     "osenv": "^0.1.3",
     "pull-bitflipper": "^0.1.0",
-    "rimraf": "^2.5.2",
+    "rimraf": "^3.0.0",
     "secret-stack": "^6.0.1",
     "tape": "^4.5.1"
   },


### PR DESCRIPTION
Problem: Our npm dependencies were outdated.

Solution: `npm update`. I left behind mkdirp because it was failing the
tests with cryptic error messages and it wasn't super important to
update.