### PR TITLE
push persistence

### DIFF
--- a/blob-push.js
+++ b/blob-push.js
@@ -1,24 +1,54 @@
 const pull = require('pull-stream')
 const pl = require('pull-level')
+const Obz = require('obz')
 
-module.exports = function (db) {
-  const set = {}
+module.exports = function BlobPush (db) {
+  const state = {}
+  const isReady = Obz()
+  const updates = Obz()
 
   pull(
-    pl.read(db, { live: true }),
-    pull.drain(function (e) {
-      // if (!e.sync) {}
-      if (e.type === 'del') delete set[e.key]
-      else set[e.key] = e.value
+    pl.read(db, { old: true, live: false }),
+    pull.drain(
+      (e) => {
+        if (e.type === 'del') delete state[e.key]
+        else state[e.key] = e.value
+      },
+      (err) => {
+        if (err) throw err
+
+        updates.set(state)
+        isReady.set(true)
+      }
+    )
+  )
+
+  pull(
+    pl.read(db, { live: true, old: false }),
+    pull.drain(e => {
+      if (e.type === 'del') delete state[e.key]
+      else {
+        if (!(e.key in state)) {
+          updates.set({ [e.key]: e.value })
+        }
+        state[e.key] = e.value
+      }
     })
   )
 
   return {
-    set: set,
-    add: function (key, cb) {
-      db.put(key, -1, cb)
+    onReady (fn) {
+      if (isReady.value === true) return fn()
+
+      isReady.once(fn)
     },
-    remove: function (key, cb) {
+    updates,
+    add (key, cb) {
+      db.put(key, -1, cb)
+      // why was this set to -1?
+      // was this meaning to say "I want this", or track how many we've pushed to?
+    },
+    remove (key, cb) {
       db.del(key, cb)
     }
   }

--- a/index.js
+++ b/index.js
@@ -31,6 +31,9 @@ exports.permissions = {
 
 exports.init = function (sbot, config) {
   const level = Level(path.join(config.path, 'blobs_push'), { valueEncoding: 'json' })
+  sbot.close.hook(function (fn, args) {
+    level.close(() => fn(...args))
+  })
 
   const blobs = Inject(
     BlobStore(path.join(config.path, 'blobs')),
@@ -42,10 +45,6 @@ exports.init = function (sbot, config) {
   sbot.on('rpc:connect', function (rpc) {
     if (rpc.id === sbot.id) return
     blobs._onConnect(rpc, rpc.id)
-  })
-
-  sbot.close.hook(function (fn, args) {
-    level.close(() => fn(...args))
   })
 
   return blobs

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "level": "^6.0.0",
     "multiblob": "^1.12.0",
+    "obz": "^1.0.2",
+    "pull-defer": "^0.2.3",
     "pull-level": "^2.0.4",
     "pull-notify": "^0.1.0",
     "pull-stream": "^3.3.0",

--- a/test/mock/blob-push.js
+++ b/test/mock/blob-push.js
@@ -1,16 +1,32 @@
+const Obz = require('obz')
 const debug = require('debug')('ssb-blobs')
 
 module.exports = function (async) {
   debug(async)
-  const set = {}
+
+  const state = {}
+  const isReady = Obz()
+  const updates = Obz()
+
+  setTimeout(() => {
+    updates.set({})
+    isReady.set(true)
+  }, 300)
+
   return {
-    set: set,
+    updates,
+    onReady (fn) {
+      if (isReady.value === true) return fn()
+
+      isReady.once(fn)
+    },
     add: async(function (key, cb) {
-      set[key] = true
+      if (!(key in state)) updates.set({ [key]: true })
+      state[key] = true
       cb && async(cb)()
     }),
     remove: async(function (key, cb) {
-      delete set[key]
+      delete state[key]
       cb && async(cb)()
     })
   }

--- a/test/mock/blob-store.js
+++ b/test/mock/blob-store.js
@@ -52,9 +52,22 @@ module.exports = function MockBlobStore (name, async) {
       blobId = blobId.key || blobId
       if (blobId === empty) return pull.empty()
 
-      if (store[blobId] && max && store[blobId].length > max) { return pull(pull.error(new Error('bigger than max:' + blobId)), async.through('get-error')) }
-      if (!store[blobId]) { return pull(pull.error(new Error('no blob:' + blobId)), async.through('get-error')) }
-      return pull(pull.values([store[blobId]]), async.through('get'))
+      if (store[blobId] && max && store[blobId].length > max) {
+        return pull(
+          pull.error(new Error('bigger than max:' + blobId)),
+          async.through('get-error')
+        )
+      }
+      if (!store[blobId]) {
+        return pull(
+          pull.error(new Error('no blob:' + blobId)),
+          async.through('get-error')
+        )
+      }
+      return pull(
+        pull.values([store[blobId]]),
+        async.through('get')
+      )
     },
     isEmptyHash: function (h) {
       return h === empty
@@ -92,17 +105,20 @@ module.exports = function MockBlobStore (name, async) {
       }
       if (!cb) cb = (err) => { if (err) throw err }
 
-      return pull(async.through('add'), pull.collect(async(function (err, data) {
-        if (err) return cb(err)
-        data = Buffer.concat(data)
-        const h = add(data, _hash)
-        debug('..ADDED', name, h)
-        if (!h) cb(new Error('wrong hash'))
-        else {
-          notify({ id: h, size: data.length, ts: Date.now() })
-          cb(null, h)
-        }
-      }, 'add-cb')))
+      return pull(
+        async.through('add'),
+        pull.collect(async(function (err, data) {
+          if (err) return cb(err)
+          data = Buffer.concat(data)
+          const h = add(data, _hash)
+          debug('..ADDED', name, h)
+          if (!h) cb(new Error('wrong hash'))
+          else {
+            notify({ id: h, size: data.length, ts: Date.now() })
+            cb(null, h)
+          }
+        }, 'add-cb'))
+      )
     }
   }
 }

--- a/test/secret-stack.js
+++ b/test/secret-stack.js
@@ -50,6 +50,79 @@ tape('secret-stack - alice pushes to bob', function (t) {
   })
 })
 
+tape('secret-stack - push persistence', function (t) {
+  t.plan(4)
+  const name = 'alice-restart'
+  let alice = Server({ name, caps })
+  const bob = Server({ caps })
+
+  let _hash
+  const hello = Buffer.from('Hello World')
+
+  pull(
+    pull.once(hello),
+    alice.blobs.add(function (err, hash) {
+      t.error(err, 'alice adds blob')
+      _hash = hash
+      alice.blobs.push(hash)
+
+      alice.close(err => {
+        t.error(err, 'alice restarts')
+        alice = Server({ name, caps, startUnclean: true })
+
+        const finish = () => {
+          alice.close()
+          bob.close()
+        }
+        const timeout = setTimeout(
+          () => {
+            t.fail('bob receives blob')
+            finish()
+          },
+          2000
+        )
+
+        pull(
+          bob.blobs.ls({ live: true, long: true }),
+          pull.filter((msg) => !msg.sync),
+          pull.take(1),
+          pull.collect(function (err, ary) {
+            clearTimeout(timeout)
+            if (err) throw err
+
+            t.equal(ary[0].id, _hash, 'bob receives blob')
+            finish()
+          })
+        )
+
+        alice.connect(bob.address(), function (err, rpc) {
+          t.error(err, 'alice connects to bob')
+        })
+      })
+    })
+  )
+})
+
+tape('secret-stack - blobs.max', t => {
+  t.plan(1)
+  const hello = Buffer.from('Hello World')
+
+  const alice = Server({
+    blobs: {
+      max: hello.length // NOTE the size must be *under* max NOT <=
+    }
+  })
+
+  pull(
+    pull.once(hello),
+    alice.blobs.add(function (err, hash) {
+      const errMsg = (err && err.stack) || 'NO ERROR FOR TEST TO COMPARE!!'
+      t.match(errMsg, /bigger than blobs.max/, 'are not allowed to add blobs that are > max')
+      alice.close()
+    })
+  )
+})
+
 tape('secret-stack - close', t => {
   t.plan(1)
   const keys = generate()

--- a/test/suite/legacy.js
+++ b/test/suite/legacy.js
@@ -19,7 +19,6 @@ module.exports = function (createBlobs, createAsync, groupName = '?') {
 
     createAsync(function (async) {
       // legacy tests
-
       let n = 0
 
       const modern = createBlobs('modern', async)

--- a/test/suite/push.js
+++ b/test/suite/push.js
@@ -54,8 +54,14 @@ module.exports = function (createBlobs, createAsync, groupName = '?') {
         })
       )
 
-      pull(pull.once(blob), alice.add())
-      alice.push(h)
+      pull(
+        pull.once(blob),
+        alice.add((err, blobId) => {
+          if (err) throw err
+
+          alice.push(blobId)
+        })
+      )
     }, function (err) {
       if (err) throw err
     })

--- a/test/suite/simple.js
+++ b/test/suite/simple.js
@@ -20,8 +20,10 @@ module.exports = function (createBlobs, createAsync, groupName = '?') {
     createAsync(function (async) {
       const blobs = createBlobs('simple', async)
       debug(blobs)
-      const b = Fake('hello', 256); const h = hash(b)
+      const b = Fake('hello', 256)
+      const h = hash(b)
       pull(pull.once(b), async.through(), blobs.add(h, function (err, _h) {
+        console.log(err, _h)
         if (err) throw err
         debug('added', _h)
         t.equal(_h, h)
@@ -108,11 +110,11 @@ module.exports = function (createBlobs, createAsync, groupName = '?') {
       pull(
         blobs.createWants.call({ id: 'test' }),
         async.through(),
-        pull.take(2),
+        pull.take(1),
         pull.collect(function (err, _res) {
           if (err) throw err
           // requests
-          t.deepEqual(_res, [{}, res])
+          t.deepEqual(_res, [res])
           async.done()
         })
       )


### PR DESCRIPTION
**Problem**: with Ahau we saw that sometimes when a person started offline and later connected to their first pub, sometimes their blobs just did not come through.


**Solution** : What I saw was that there was a db which was recording things to push, but this db wasn't being loaded into memory after restarts. This PR adds a test for that and solves it.

(In the process I did a lot of refactoring to make the code tidier - by my definition - and easier to read / maintain. I've done a lot of different PRs to remove those non-functional changes from this PR. There's still a couple of tidying things in here but hopefully it's fine)

Files which are important:
- `inject.js` - modified so that list of blobs to push is always loaded from db
- `blob-push` - modified to track loaded state, and create a stream of updates to list of blobs to push

Commit history:
- sorry this is messy, I did the work then extracted the non-functional changes into other PRs to make this PR smaller /easier to review
- I plan to merge-squash these commits once ready